### PR TITLE
Fix darwin target to work in github actions

### DIFF
--- a/.github/workflows/darwin.yml
+++ b/.github/workflows/darwin.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           go-version: '1.16.1'
       - name: Build
-        run: make binding_darwin_github_actions_limit_macos
+        run: make binding_darwin
       - name: Compress
         run: tar -czvf output.tar.gz -C output/binding/darwin .
       - if: ${{ env.VERSION!='' }}

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ BINDING_NAME?=libopenpgp_bridge
 BINDING_FILE?=$(BINDING_NAME).so
 BINDING_ARGS?=
 BINDING_OUTPUT?=$(OUTPUT_DIR)/binding
+BINDING_SDKROOT?=
 
 default: fmt test
 
@@ -21,6 +22,7 @@ clean:
 
 binding: deps
 	mkdir -p $(BINDING_OUTPUT)
+	SDKROOT=$(BINDING_SDKROOT) \
 	go build -ldflags="-w -s" -o $(BINDING_OUTPUT)/$(BINDING_FILE) -buildmode=$(BUILD_MODE) $(BINDING_ARGS) binding/main.go
 
 include Makefile.android

--- a/Makefile.darwin
+++ b/Makefile.darwin
@@ -1,15 +1,11 @@
 DARWIN_OUTPUT?=darwin
 DARWIN_BINDING_OUTPUT?=$(BINDING_OUTPUT)/$(DARWIN_OUTPUT)
 DARWIN_TARGET?=10.11
+DARWIN_SDKROOT?=$(shell xcrun --sdk macosx --show-sdk-path)
 
 binding_darwin: binding_darwin_x86_64 binding_darwin_arm64
 	lipo $(DARWIN_BINDING_OUTPUT)/x86_64.dylib $(DARWIN_BINDING_OUTPUT)/arm64.dylib -create -output $(DARWIN_BINDING_OUTPUT)/$(BINDING_NAME).dylib
 	rm $(DARWIN_BINDING_OUTPUT)/x86_64.dylib $(DARWIN_BINDING_OUTPUT)/arm64.dylib $(DARWIN_BINDING_OUTPUT)/*.h
-
-# this exists only bc of github actions
-binding_darwin_github_actions_limit_macos: binding_darwin_x86_64
-	mv $(DARWIN_BINDING_OUTPUT)/x86_64.dylib $(DARWIN_BINDING_OUTPUT)/$(BINDING_NAME).dylib
-	rm $(DARWIN_BINDING_OUTPUT)/*.h
 
 binding_darwin_x86_64:
 	BINDING_FILE=$(DARWIN_OUTPUT)/x86_64.dylib \
@@ -25,6 +21,7 @@ binding_darwin_arm64:
 	CGO_CFLAGS=-mmacosx-version-min=$(DARWIN_TARGET) \
 	MACOSX_DEPLOYMENT_TARGET=$(DARWIN_TARGET) \
 	GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 \
+	BINDING_SDKROOT=$(DARWIN_SDKROOT) \
 	make binding
 
 binding_darwin_archive_x86_64:


### PR DESCRIPTION
Firstly I wanted to say thank you for your work. OpenPGP mobile and it's flutter sister repo are one of the best and most complete examples on building golang and flutter integrations.

While trying to do something similar in a different golang project of mine, I bumped into what is possibly the same issue you were having that resulted in only bulding the x86_64 variant for macos.

This PR simply adds the SDKROOT as suggested in https://github.com/golang/go/issues/44112#issue-801809091

Tried running this on my fork and seems ok.